### PR TITLE
Add some Pydantic model dump attributes

### DIFF
--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -63,13 +63,13 @@ class BareModel(pydantic.BaseModel, ABC):
     __document_id__: str
     __ttl_field__: Optional[str] = None
 
-    def save(self) -> None:
+    def save(self, by_alias: bool = True, exclude_unset: bool = False, exclude_none: bool = False) -> None:
         """
         Saves this model in the database.
 
         :raise DocumentIDError: If the document ID is not valid.
         """
-        data = self.model_dump(by_alias=True)
+        data = self.model_dump(by_alias=by_alias, exclude_unset=exclude_unset, exclude_none=exclude_none)
         if self.__document_id__ in data:
             del data[self.__document_id__]
 


### PR DESCRIPTION
I'd like to be able to exclude unset and null fields from being saved to firestore