### PR TITLE
Fix issues with indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Don't raise an `AttributeError` when setting up indexes for models if there's a model
   without any indexes (i.e. a model does not at all define the `__composite_indexes__`).
-- Fix bug that the configured prefix was not used when creating indexes.
+- Fix bug that the configured prefix was not used when creating indexes. Please note
+  that if you have been using indexes and a collection name prefix, the indexes created
+  before this fix will be for the wrong collection names (i.e. missing the prefix)! Thus
+  please go through your indexes and remove the accidentally created ones after updating
+  to this version.
 
 ## [0.7.0] - 2024-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.7.1] - 2024-06-13
+
+### Changed
+
+- Don't raise an `AttributeError` when setting up indexes for models if there's a model
+  without any indexes (i.e. a model does not at all define the `__composite_indexes__`).
+
 ## [0.7.0] - 2024-03-27
 
 ### Added
@@ -218,7 +225,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update README.md
 - Update .gitignore
 
-[unreleased]: https://github.com/ioxiocom/firedantic/compare/0.7.0...HEAD
+[unreleased]: https://github.com/ioxiocom/firedantic/compare/0.7.1...HEAD
+[0.7.1]: https://github.com/ioxiocom/firedantic/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/ioxiocom/firedantic/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/ioxiocom/firedantic/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/ioxiocom/firedantic/compare/0.5.0...0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-## [0.7.1] - 2024-06-13
+## [0.7.1] - 2024-06-14
 
-### Changed
+### Fixed
 
 - Don't raise an `AttributeError` when setting up indexes for models if there's a model
   without any indexes (i.e. a model does not at all define the `__composite_indexes__`).
+- Fix bug that the configured prefix was not used when creating indexes.
 
 ## [0.7.0] - 2024-03-27
 

--- a/firedantic/_async/indexes.py
+++ b/firedantic/_async/indexes.py
@@ -104,7 +104,7 @@ async def set_up_composite_indexes(
             continue
         path = (
             f"projects/{gcloud_project}/databases/{database}/"
-            f"collectionGroups/{model.__collection__}"
+            f"collectionGroups/{model.get_collection_name()}"
         )
         indexes_in_db = await get_existing_indexes(client, path=path)
         model_indexes = set(model.__composite_indexes__)

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -63,7 +63,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
     __collection__: Optional[str] = None
     __document_id__: str
     __ttl_field__: Optional[str] = None
-    __composite_indexes__: Optional[Iterable[IndexDefinition]]
+    __composite_indexes__: Optional[Iterable[IndexDefinition]] = None
 
     async def save(self) -> None:
         """

--- a/firedantic/_sync/indexes.py
+++ b/firedantic/_sync/indexes.py
@@ -104,7 +104,7 @@ def set_up_composite_indexes(
             continue
         path = (
             f"projects/{gcloud_project}/databases/{database}/"
-            f"collectionGroups/{model.__collection__}"
+            f"collectionGroups/{model.get_collection_name()}"
         )
         indexes_in_db = get_existing_indexes(client, path=path)
         model_indexes = set(model.__composite_indexes__)

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -63,7 +63,7 @@ class BareModel(pydantic.BaseModel, ABC):
     __collection__: Optional[str] = None
     __document_id__: str
     __ttl_field__: Optional[str] = None
-    __composite_indexes__: Optional[Iterable[IndexDefinition]]
+    __composite_indexes__: Optional[Iterable[IndexDefinition]] = None
 
     def save(self) -> None:
         """

--- a/firedantic/tests/tests_async/test_indexes.py
+++ b/firedantic/tests/tests_async/test_indexes.py
@@ -4,6 +4,7 @@ from google.cloud.firestore import Query
 from google.cloud.firestore_admin_v1 import ListIndexesResponse
 
 from firedantic import (
+    CONFIGURATIONS,
     AsyncModel,
     async_set_up_composite_indexes,
     async_set_up_composite_indexes_and_ttl_policies,
@@ -40,7 +41,10 @@ async def test_set_up_composite_index(mock_admin_client):
     call_list = mock_admin_client.create_index.call_args_list
     # index is a protobuf structure sent via Google Cloud Admin
     path = call_list[0][1]["request"].parent
-    assert path == "projects/proj/databases/(default)/collectionGroups/modelWithIndexes"
+    assert (
+        path
+        == f"projects/proj/databases/(default)/collectionGroups/{CONFIGURATIONS['prefix']}modelWithIndexes"
+    )
     index = call_list[0][1]["request"].index
     assert index.query_scope.name == "COLLECTION"
     assert len(index.fields) == 2
@@ -69,7 +73,10 @@ async def test_set_up_collection_group_index(mock_admin_client):
     call_list = mock_admin_client.create_index.call_args_list
     # index is a protobuf structure sent via Google Cloud Admin
     path = call_list[0][1]["request"].parent
-    assert path == "projects/proj/databases/(default)/collectionGroups/modelWithIndexes"
+    assert (
+        path
+        == f"projects/proj/databases/(default)/collectionGroups/{CONFIGURATIONS['prefix']}modelWithIndexes"
+    )
     index = call_list[0][1]["request"].index
     assert index.query_scope.name == "COLLECTION_GROUP"
     assert len(index.fields) == 2
@@ -140,7 +147,7 @@ async def test_existing_indexes_are_skipped(mock_admin_client):
                 {
                     "name": (
                         "projects/fake-project/databases/(default)/collectionGroups/"
-                        "modelWithIndexes/123456"
+                        f"{CONFIGURATIONS['prefix']}modelWithIndexes/123456"
                     ),
                     "query_scope": "COLLECTION",
                     "fields": [
@@ -152,7 +159,7 @@ async def test_existing_indexes_are_skipped(mock_admin_client):
                 {
                     "name": (
                         "projects/fake-project/databases/(default)/collectionGroups/"
-                        "modelWithIndexes/67889"
+                        f"{CONFIGURATIONS['prefix']}modelWithIndexes/67889"
                     ),
                     "query_scope": "COLLECTION",
                     "fields": [
@@ -192,7 +199,7 @@ async def test_same_fields_in_another_collection(mock_admin_client):
                 {
                     "name": (
                         "projects/fake-project/databases/(default)/collectionGroups/"
-                        "anotherModel/123456"
+                        f"{CONFIGURATIONS['prefix']}anotherModel/123456"
                     ),
                     "query_scope": "COLLECTION",
                     "fields": [

--- a/firedantic/tests/tests_async/test_indexes.py
+++ b/firedantic/tests/tests_async/test_indexes.py
@@ -115,6 +115,24 @@ async def test_set_up_many_composite_indexes(mock_admin_client):
 
 
 @pytest.mark.asyncio
+async def test_set_up_indexes_model_without_indexes(mock_admin_client):
+    class ModelWithoutIndexes(AsyncModel):
+        __collection__ = "modelWithoutIndexes"
+
+        name: str
+
+    result = await async_set_up_composite_indexes(
+        gcloud_project="proj",
+        models=[ModelWithoutIndexes],
+        client=mock_admin_client,
+    )
+    assert len(result) == 0
+
+    call_list = mock_admin_client.create_index.call_args_list
+    assert len(call_list) == 0
+
+
+@pytest.mark.asyncio
 async def test_existing_indexes_are_skipped(mock_admin_client):
     resp = ListIndexesResponse(
         {

--- a/firedantic/tests/tests_sync/test_indexes.py
+++ b/firedantic/tests/tests_sync/test_indexes.py
@@ -4,6 +4,7 @@ from google.cloud.firestore import Query
 from google.cloud.firestore_admin_v1 import ListIndexesResponse
 
 from firedantic import (
+    CONFIGURATIONS,
     Model,
     collection_group_index,
     collection_index,
@@ -39,7 +40,10 @@ def test_set_up_composite_index(mock_admin_client):
     call_list = mock_admin_client.create_index.call_args_list
     # index is a protobuf structure sent via Google Cloud Admin
     path = call_list[0][1]["request"].parent
-    assert path == "projects/proj/databases/(default)/collectionGroups/modelWithIndexes"
+    assert (
+        path
+        == f"projects/proj/databases/(default)/collectionGroups/{CONFIGURATIONS['prefix']}modelWithIndexes"
+    )
     index = call_list[0][1]["request"].index
     assert index.query_scope.name == "COLLECTION"
     assert len(index.fields) == 2
@@ -67,7 +71,10 @@ def test_set_up_collection_group_index(mock_admin_client):
     call_list = mock_admin_client.create_index.call_args_list
     # index is a protobuf structure sent via Google Cloud Admin
     path = call_list[0][1]["request"].parent
-    assert path == "projects/proj/databases/(default)/collectionGroups/modelWithIndexes"
+    assert (
+        path
+        == f"projects/proj/databases/(default)/collectionGroups/{CONFIGURATIONS['prefix']}modelWithIndexes"
+    )
     index = call_list[0][1]["request"].index
     assert index.query_scope.name == "COLLECTION_GROUP"
     assert len(index.fields) == 2
@@ -134,7 +141,7 @@ def test_existing_indexes_are_skipped(mock_admin_client):
                 {
                     "name": (
                         "projects/fake-project/databases/(default)/collectionGroups/"
-                        "modelWithIndexes/123456"
+                        f"{CONFIGURATIONS['prefix']}modelWithIndexes/123456"
                     ),
                     "query_scope": "COLLECTION",
                     "fields": [
@@ -146,7 +153,7 @@ def test_existing_indexes_are_skipped(mock_admin_client):
                 {
                     "name": (
                         "projects/fake-project/databases/(default)/collectionGroups/"
-                        "modelWithIndexes/67889"
+                        f"{CONFIGURATIONS['prefix']}modelWithIndexes/67889"
                     ),
                     "query_scope": "COLLECTION",
                     "fields": [
@@ -183,7 +190,7 @@ def test_same_fields_in_another_collection(mock_admin_client):
                 {
                     "name": (
                         "projects/fake-project/databases/(default)/collectionGroups/"
-                        "anotherModel/123456"
+                        f"{CONFIGURATIONS['prefix']}anotherModel/123456"
                     ),
                     "query_scope": "COLLECTION",
                     "fields": [

--- a/firedantic/tests/tests_sync/test_indexes.py
+++ b/firedantic/tests/tests_sync/test_indexes.py
@@ -110,6 +110,23 @@ def test_set_up_many_composite_indexes(mock_admin_client):
     assert len(result) == 3
 
 
+def test_set_up_indexes_model_without_indexes(mock_admin_client):
+    class ModelWithoutIndexes(Model):
+        __collection__ = "modelWithoutIndexes"
+
+        name: str
+
+    result = set_up_composite_indexes(
+        gcloud_project="proj",
+        models=[ModelWithoutIndexes],
+        client=mock_admin_client,
+    )
+    assert len(result) == 0
+
+    call_list = mock_admin_client.create_index.call_args_list
+    assert len(call_list) == 0
+
+
 def test_existing_indexes_are_skipped(mock_admin_client):
     resp = ListIndexesResponse(
         {

--- a/poetry.lock
+++ b/poetry.lock
@@ -336,13 +336,13 @@ protobuf = ">=3.12.0"
 
 [[package]]
 name = "idna"
-version = "3.2"
+version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},
-    {file = "idna-3.2.tar.gz", hash = "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"},
+    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
+    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
 ]
 
 [[package]]
@@ -773,13 +773,13 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "requests"
-version = "2.31.0"
+version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "firedantic"
-version = "0.7.0"
+version = "0.7.1"
 description = "Pydantic base models for Firestore"
 authors = ["IOXIO Ltd"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
There was two issues with setting up indexes:
1. An AttributeError was raised when setting up indexes if there's a model that have no indexes.
If you set up indexes using the approach suggested in the README, i.e. `models=get_all_subclasses(Model)`, and there's at least one sub-model that does not define `__composite_indexes__` an `AttributeError` was raised. This PR fixes that by adding the default value `None`, so you don't need to manually define it for each sub-class or make your own intermediate base class.
2. If you defined a prefix for the collections, the prefix was ignored when creating the indexes, i.e. you didn't get an index for the collection you were actually using, but for one with the same name minus the prefix.