### PR TITLE
Fix issue with TTL policies in set_up_composite_indexes_and_ttl_policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.7.2] - 2024-06-17
+
+### Fixed
+
+- Ensure TTL policies are created by `async_set_up_composite_indexes_and_ttl_policies`
+  and `set_up_composite_indexes_and_ttl_policies` also when passing in the models as a
+  generator, for example when using `get_all_subclasses()`.
+
 ## [0.7.1] - 2024-06-14
 
 ### Fixed
@@ -230,7 +238,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update README.md
 - Update .gitignore
 
-[unreleased]: https://github.com/ioxiocom/firedantic/compare/0.7.1...HEAD
+[unreleased]: https://github.com/ioxiocom/firedantic/compare/0.7.2...HEAD
+[0.7.2]: https://github.com/ioxiocom/firedantic/compare/0.7.1...0.7.2
 [0.7.1]: https://github.com/ioxiocom/firedantic/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/ioxiocom/firedantic/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/ioxiocom/firedantic/compare/0.5.1...0.6.0

--- a/firedantic/_async/indexes.py
+++ b/firedantic/_async/indexes.py
@@ -139,6 +139,7 @@ async def set_up_composite_indexes_and_ttl_policies(
     :param client: The Firestore admin client.
     :return: List of operations that were launched.
     """
+    models = list(models)
     ops = await set_up_composite_indexes(gcloud_project, models, database, client)
     ops.extend(await set_up_ttl_policies(gcloud_project, models, database, client))
     return ops

--- a/firedantic/_sync/indexes.py
+++ b/firedantic/_sync/indexes.py
@@ -139,6 +139,7 @@ def set_up_composite_indexes_and_ttl_policies(
     :param client: The Firestore admin client.
     :return: List of operations that were launched.
     """
+    models = list(models)
     ops = set_up_composite_indexes(gcloud_project, models, database, client)
     ops.extend(set_up_ttl_policies(gcloud_project, models, database, client))
     return ops

--- a/firedantic/tests/tests_async/test_indexes.py
+++ b/firedantic/tests/tests_async/test_indexes.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import AsyncMock
 
 from google.cloud.firestore import Query
@@ -89,12 +90,15 @@ async def test_set_up_composite_indexes_and_policies(mock_admin_client):
             collection_index(("name", Query.ASCENDING), ("age", Query.DESCENDING)),
         )
 
+        __ttl_field__ = "expire"
+        expire: datetime
+
     result = await async_set_up_composite_indexes_and_ttl_policies(
         gcloud_project="proj",
-        models=[ModelWithIndexes],
+        models=(model for model in [ModelWithIndexes]),  # Test with a generator
         client=mock_admin_client,
     )
-    assert len(result) == 1
+    assert len(result) == 2
 
     call_list = mock_admin_client.create_index.call_args_list
     assert len(call_list) == 1

--- a/firedantic/tests/tests_sync/test_indexes.py
+++ b/firedantic/tests/tests_sync/test_indexes.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import Mock
 
 from google.cloud.firestore import Query
@@ -86,12 +87,15 @@ def test_set_up_composite_indexes_and_policies(mock_admin_client):
             collection_index(("name", Query.ASCENDING), ("age", Query.DESCENDING)),
         )
 
+        __ttl_field__ = "expire"
+        expire: datetime
+
     result = set_up_composite_indexes_and_ttl_policies(
         gcloud_project="proj",
-        models=[ModelWithIndexes],
+        models=(model for model in [ModelWithIndexes]),  # Test with a generator
         client=mock_admin_client,
     )
-    assert len(result) == 1
+    assert len(result) == 2
 
     call_list = mock_admin_client.create_index.call_args_list
     assert len(call_list) == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "firedantic"
-version = "0.7.1"
+version = "0.7.2"
 description = "Pydantic base models for Firestore"
 authors = ["IOXIO Ltd"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
This PR fixes the issue that if you were using `get_all_subclasses()` to gather the models to pass into the `async_set_up_composite_indexes_and_ttl_policies()` or `set_up_composite_indexes_and_ttl_policies()` like suggested in the README, like this:
```python
    await async_set_up_composite_indexes_and_ttl_policies(
        gcloud_project="my-project",
        models=get_all_subclasses(AsyncModel),
        client=FirestoreAdminAsyncClient(),
    )
```
the indexes were created but the TTL policies were not. The `get_all_subclasses()` method returns an iterator and the underlying `set_up_composite_indexes` used up the generator so that the call to the `set_up_ttl_policies` got an empty generator. This fixes it by simply converting it to a list before passing it to each of the underlying functions and updates the test to spot the issue.