### PR TITLE
Added support for `exclude_none` and `exclude_unset` in `save` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `exclude_none` and `exclude_unset` in `save` method.
+
 ## [0.8.1] - 2024-12-09
 
 ### Changed

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -65,13 +65,19 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
     __ttl_field__: Optional[str] = None
     __composite_indexes__: Optional[Iterable[IndexDefinition]] = None
 
-    async def save(self) -> None:
+    async def save(
+        self, *, exclude_unset: bool = False, exclude_none: bool = False
+    ) -> None:
         """
         Saves this model in the database.
 
+        :param exclude_unset: Whether to exclude fields that have not been explicitly set.
+        :param exclude_none: Whether to exclude fields that have a value of `None`.
         :raise DocumentIDError: If the document ID is not valid.
         """
-        data = self.model_dump(by_alias=True)
+        data = self.model_dump(
+            by_alias=True, exclude_unset=exclude_unset, exclude_none=exclude_none
+        )
         if self.__document_id__ in data:
             del data[self.__document_id__]
 

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -65,13 +65,17 @@ class BareModel(pydantic.BaseModel, ABC):
     __ttl_field__: Optional[str] = None
     __composite_indexes__: Optional[Iterable[IndexDefinition]] = None
 
-    def save(self) -> None:
+    def save(self, *, exclude_unset: bool = False, exclude_none: bool = False) -> None:
         """
         Saves this model in the database.
 
+        :param exclude_unset: Whether to exclude fields that have not been explicitly set.
+        :param exclude_none: Whether to exclude fields that have a value of `None`.
         :raise DocumentIDError: If the document ID is not valid.
         """
-        data = self.model_dump(by_alias=True)
+        data = self.model_dump(
+            by_alias=True, exclude_unset=exclude_unset, exclude_none=exclude_none
+        )
         if self.__document_id__ in data:
             del data[self.__document_id__]
 

--- a/firedantic/tests/tests_async/conftest.py
+++ b/firedantic/tests/tests_async/conftest.py
@@ -67,6 +67,7 @@ class Owner(BaseModel):
 
 class CompanyStats(AsyncBareSubModel):
     _doc_id: Optional[str] = PrivateAttr()
+
     sales: int
 
     class Collection(AsyncBareSubCollection):
@@ -93,6 +94,7 @@ class Company(AsyncModel):
     """Dummy company Firedantic model."""
 
     __collection__ = "companies"
+
     company_id: str
     owner: Owner
 
@@ -107,6 +109,7 @@ class Product(AsyncModel):
     """Dummy product Firedantic model."""
 
     __collection__ = "products"
+
     product_id: str
     price: float
     stock: int
@@ -115,8 +118,23 @@ class Product(AsyncModel):
         extra = Extra.forbid
 
 
+class Profile(AsyncModel):
+    """Dummy profile Firedantic model."""
+
+    __collection__ = "profiles"
+
+    name: Optional[str] = ""
+    photo_url: Optional[str] = None
+
+    class Config:
+        extra = Extra.forbid
+
+
 class TodoList(AsyncModel):
+    """Dummy todo list Firedantic model."""
+
     __collection__ = "todoLists"
+
     name: str
     items: List[str]
 
@@ -125,6 +143,8 @@ class TodoList(AsyncModel):
 
 
 class ExpiringModel(AsyncModel):
+    """Dummy expiring model Firedantic model."""
+
     __collection__ = "expiringModel"
     __ttl_field__ = "expire"
 
@@ -173,9 +193,9 @@ def create_product():
 @pytest.fixture
 def create_todolist():
     async def _create(name: str, items: List[str]):
-        p = TodoList(name=name, items=items)
-        await p.save()
-        return p
+        t = TodoList(name=name, items=items)
+        await t.save()
+        return t
 
     return _create
 

--- a/firedantic/tests/tests_sync/conftest.py
+++ b/firedantic/tests/tests_sync/conftest.py
@@ -67,6 +67,7 @@ class Owner(BaseModel):
 
 class CompanyStats(BareSubModel):
     _doc_id: Optional[str] = PrivateAttr()
+
     sales: int
 
     class Collection(BareSubCollection):
@@ -93,6 +94,7 @@ class Company(Model):
     """Dummy company Firedantic model."""
 
     __collection__ = "companies"
+
     company_id: str
     owner: Owner
 
@@ -107,6 +109,7 @@ class Product(Model):
     """Dummy product Firedantic model."""
 
     __collection__ = "products"
+
     product_id: str
     price: float
     stock: int
@@ -115,8 +118,23 @@ class Product(Model):
         extra = Extra.forbid
 
 
+class Profile(Model):
+    """Dummy profile Firedantic model."""
+
+    __collection__ = "profiles"
+
+    name: Optional[str] = ""
+    photo_url: Optional[str] = None
+
+    class Config:
+        extra = Extra.forbid
+
+
 class TodoList(Model):
+    """Dummy todo list Firedantic model."""
+
     __collection__ = "todoLists"
+
     name: str
     items: List[str]
 
@@ -125,6 +143,8 @@ class TodoList(Model):
 
 
 class ExpiringModel(Model):
+    """Dummy expiring model Firedantic model."""
+
     __collection__ = "expiringModel"
     __ttl_field__ = "expire"
 
@@ -171,9 +191,9 @@ def create_product():
 @pytest.fixture
 def create_todolist():
     def _create(name: str, items: List[str]):
-        p = TodoList(name=name, items=items)
-        p.save()
-        return p
+        t = TodoList(name=name, items=items)
+        t.save()
+        return t
 
     return _create
 


### PR DESCRIPTION
Hello! I liked the suggestion from @expressintegrations to add support for the `exclude_none` and `exclude_unset` options available in Pydantic BaseModel's `model_dump` method (https://github.com/ioxiocom/firedantic/pull/66) when saving a Model.

Since that PR seems stale, I decided to create a new one, taking into consideration the helpful comments from @fbjorn (https://github.com/ioxiocom/firedantic/pull/66#issuecomment-2527735369). 

- [x] Remove `by_alias` from the request.
- [x] Make `exclude_unset` and `exclude_none` keyword arguments.
- [x] Move changes to `_async/model.py` based on development section of readme. 
- [x] Add doc strings for new arguments.
- [x] Add unit tests that save and load the models using new arguments. 

Thanks for your consideration!

