### PR TITLE
Fix issue with publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ jobs:
           ./start_emulator.sh > /dev/null 2>&1 &
 
       - name: Install Poetry and pre-commit 💈
-        run: pip install poetry pre-commit
+        run: pip install poetry==1.8.5 pre-commit
 
       - name: Install dependencies 🛠
         run: poetry install

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
           ./start_emulator.sh > /dev/null 2>&1 &
 
       - name: Install Poetry and pre-commit 💈
-        run: pip install poetry pre-commit
+        run: pip install poetry==1.8.5 pre-commit
 
       - name: Install dependencies 🛠
         run: poetry install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Switched Firestore `query.where()` to use the 'filter' keyword argument instead of
   positional arguments. This eliminates a UserWarning that was introduced in
   `google-cloud-firestore` 2.11.0.
+- Internal, for builds only: Locked poetry in GitHub workflows to version 1.8.5, as
+  version 2.0.0 and later create METADATA files with version 2.3 instead of 2.2 and the
+  action to publish the package failed with an error about supported metadata versions
+  being 1.0, 1.1, 1.2, 2.0, 2.1, 2.2.
 
 ## [0.8.1] - 2024-12-09
 


### PR DESCRIPTION
Publishing to PyPI failed with error:
Checking dist/firedantic-0.9.0-py3-none-any.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name,
         Version.
         Make sure the distribution includes the files where those fields are
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,
         2.0, 2.1, 2.2.

From poetry-core 2.0.0 release notes:
- Create METADATA files with version 2.3 instead of 2.2 (#707).

This PR thus locks the poetry version in GitHub actions to the last 1.x series, i.e. 1.8.5.