### PR TITLE
Added support for Firestore transactions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.11.0] - 2025-06-06
+
+### Added
+
+- Support for transactions, a big thanks to `@lukwam` for this! For more details of how
+  to use this, see the new section in the README.
+
 ## [0.10.0] - 2025-02-26
 
 ### Added
@@ -283,7 +290,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update README.md
 - Update .gitignore
 
-[unreleased]: https://github.com/ioxiocom/firedantic/compare/0.10.0...HEAD
+[unreleased]: https://github.com/ioxiocom/firedantic/compare/0.11.0...HEAD
+[0.11.0]: https://github.com/ioxiocom/firedantic/compare/0.10.0...0.11.0
 [0.10.0]: https://github.com/ioxiocom/firedantic/compare/0.9.0...0.10.0
 [0.9.0]: https://github.com/ioxiocom/firedantic/compare/0.8.1...0.9.0
 [0.8.1]: https://github.com/ioxiocom/firedantic/compare/0.8.0...0.8.1

--- a/firedantic/__init__.py
+++ b/firedantic/__init__.py
@@ -32,6 +32,11 @@ from firedantic._sync.model import (
 )
 from firedantic._sync.ttl_policy import set_up_ttl_policies
 from firedantic.common import collection_group_index, collection_index
-from firedantic.configurations import CONFIGURATIONS, configure
+from firedantic.configurations import (
+    CONFIGURATIONS,
+    configure,
+    get_async_transaction,
+    get_transaction,
+)
 from firedantic.exceptions import *
 from firedantic.utils import get_all_subclasses

--- a/firedantic/_async/helpers.py
+++ b/firedantic/_async/helpers.py
@@ -4,7 +4,8 @@ from google.cloud.firestore_v1 import AsyncCollectionReference
 async def truncate_collection(
     col_ref: AsyncCollectionReference, batch_size: int = 128
 ) -> int:
-    """Removes all documents inside a collection.
+    """
+    Removes all documents inside a collection.
 
     :param col_ref: A collection reference to the collection to be truncated.
     :param batch_size: Batch size for listing documents.

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -10,6 +10,7 @@ from google.cloud.firestore_v1 import (
     FieldFilter,
 )
 from google.cloud.firestore_v1.async_query import AsyncQuery
+from google.cloud.firestore_v1.async_transaction import AsyncTransaction
 
 import firedantic.operators as op
 from firedantic import async_truncate_collection
@@ -41,6 +42,11 @@ FIND_TYPES = {
 
 
 def get_collection_name(cls, name: Optional[str]) -> str:
+    """
+    Returns the collection name.
+
+    :raise CollectionNotDefined: If the collection name is not defined.
+    """
     if not name:
         raise CollectionNotDefined(f"Missing collection name for {cls.__name__}")
 
@@ -55,7 +61,8 @@ def _get_col_ref(cls, name: Optional[str]) -> AsyncCollectionReference:
 
 
 class AsyncBareModel(pydantic.BaseModel, ABC):
-    """Base model class.
+    """
+    Base model class.
 
     Implements basic functionality for Pydantic models, such as save, delete, find etc.
     """
@@ -66,13 +73,18 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
     __composite_indexes__: Optional[Iterable[IndexDefinition]] = None
 
     async def save(
-        self, *, exclude_unset: bool = False, exclude_none: bool = False
+        self,
+        *,
+        exclude_unset: bool = False,
+        exclude_none: bool = False,
+        transaction: Optional[AsyncTransaction] = None,
     ) -> None:
         """
         Saves this model in the database.
 
         :param exclude_unset: Whether to exclude fields that have not been explicitly set.
         :param exclude_none: Whether to exclude fields that have a value of `None`.
+        :param transaction: Optional Transaction to use.
         :raise DocumentIDError: If the document ID is not valid.
         """
         data = self.model_dump(
@@ -82,28 +94,35 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
             del data[self.__document_id__]
 
         doc_ref = self._get_doc_ref()
-        await doc_ref.set(data)
+        if transaction is not None:
+            transaction.set(doc_ref, data)
+        else:
+            await doc_ref.set(data)
         setattr(self, self.__document_id__, doc_ref.id)
 
-    async def delete(self) -> None:
+    async def delete(self, transaction: Optional[AsyncTransaction] = None) -> None:
         """
         Deletes this model from the database.
 
         :raise DocumentIDError: If the ID is not valid.
         """
-        await self._get_doc_ref().delete()
+        if transaction is not None:
+            transaction.delete(self._get_doc_ref())
+        else:
+            await self._get_doc_ref().delete()
 
-    async def reload(self) -> None:
+    async def reload(self, transaction: Optional[AsyncTransaction] = None) -> None:
         """
         Reloads this model from the database.
 
+        :param transaction: Optional Transaction to use.
         :raise ModelNotFoundError: If the document ID is missing in the model.
         """
         doc_id = self.__dict__.get(self.__document_id__)
         if doc_id is None:
             raise ModelNotFoundError("Can not reload unsaved model")
 
-        updated_model = await self.get_by_doc_id(doc_id)
+        updated_model = await self.get_by_doc_id(doc_id, transaction=transaction)
         updated_model_doc_id = updated_model.__dict__[self.__document_id__]
         assert doc_id == updated_model_doc_id
 
@@ -111,7 +130,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
     def get_document_id(self):
         """
-        Get the document ID for this model instance
+        Returns the document ID for this model instance.
 
         :raise DocumentIDError: If the ID is not valid.
         """
@@ -123,14 +142,17 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
     _OrderBy = List[Tuple[str, OrderDirection]]
 
     @classmethod
-    async def find(
+    async def find(  # pylint: disable=too-many-arguments
         cls: Type[TAsyncBareModel],
         filter_: Optional[Dict[str, Union[str, dict]]] = None,
         order_by: Optional[_OrderBy] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        transaction: Optional[AsyncTransaction] = None,
     ) -> List[TAsyncBareModel]:
-        """Returns a list of models from the database based on a filter.
+        """
+        Returns a list of models from the database based on a filter.
+
         The list can be sorted with the order_by parameter, limits and offets can also be applied.
 
         Example: `Company.find({"company_id": "1234567-8"})`.
@@ -142,6 +164,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
         :param order_by: List of columns and direction to order results by.
         :param limit: Maximum results to return.
         :param offset: Skip the first n results.
+        :param transaction: Optional Transaction to use.
         :return: List of found models.
         """
         query: Union[AsyncQuery, AsyncCollectionReference] = cls._get_col_ref()
@@ -175,7 +198,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
         return [
             _cls(doc_id, doc_dict)
             async for doc_id, doc_dict in (
-                (doc.id, doc.to_dict()) async for doc in query.stream()  # type: ignore
+                (doc.id, doc.to_dict()) async for doc in query.stream(transaction=transaction)  # type: ignore
             )
             if doc_dict is not None
         ]
@@ -184,7 +207,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
     def _add_filter(
         cls, query: Union[AsyncQuery, AsyncCollectionReference], field: str, value: Any
     ) -> Union[AsyncQuery, AsyncCollectionReference]:
-        if type(value) is dict:
+        if isinstance(value, dict):
             for f_type in value:
                 if f_type not in FIND_TYPES:
                     raise ValueError(
@@ -193,33 +216,41 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
                 _filter = FieldFilter(field, f_type, value[f_type])
                 query: AsyncQuery = query.where(filter=_filter)  # type: ignore
             return query
-        else:
-            _filter = FieldFilter(field, "==", value)
-            query: AsyncQuery = query.where(filter=_filter)  # type: ignore
-            return query
+        _filter = FieldFilter(field, "==", value)
+        query: AsyncQuery = query.where(filter=_filter)  # type: ignore
+        return query
 
     @classmethod
     async def find_one(
         cls: Type[TAsyncBareModel],
         filter_: Optional[Dict[str, Union[str, dict]]] = None,
         order_by: Optional[_OrderBy] = None,
+        transaction: Optional[AsyncTransaction] = None,
     ) -> TAsyncBareModel:
-        """Returns one model from the DB based on a filter.
+        """
+        Returns one model from the DB based on a filter.
 
         :param filter_: The filter criteria.
         :param order_by: List of columns and direction to order results by.
         :return: The model instance.
         :raise ModelNotFoundError: If the entry is not found.
         """
-        model = await cls.find(filter_, limit=1, order_by=order_by)
+        model = await cls.find(
+            filter_, limit=1, order_by=order_by, transaction=transaction
+        )
         try:
             return model[0]
-        except IndexError:
-            raise ModelNotFoundError(f"No '{cls.__name__}' found")
+        except IndexError as e:
+            raise ModelNotFoundError(f"No '{cls.__name__}' found") from e
 
     @classmethod
-    async def get_by_doc_id(cls: Type[TAsyncBareModel], doc_id: str) -> TAsyncBareModel:
-        """Returns a model based on the document ID.
+    async def get_by_doc_id(
+        cls: Type[TAsyncBareModel],
+        doc_id: str,
+        transaction: Optional[AsyncTransaction] = None,
+    ) -> TAsyncBareModel:
+        """
+        Returns a model based on the document ID.
 
         :param doc_id: The document ID of the entry.
         :return: The model.
@@ -228,7 +259,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
         try:
             cls._validate_document_id(doc_id)
-        except InvalidDocumentID:
+        except InvalidDocumentID as e:
             # Getting a document with doc_id set to an empty string would raise a
             # google.api_core.exceptions.InvalidArgument exception and a doc_id
             # containing an uneven number of slashes would raise a
@@ -236,10 +267,10 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
             # could even load data from a sub collection instead of the desired one.
             raise ModelNotFoundError(
                 f"No '{cls.__name__}' found with {cls.__document_id__} '{doc_id}'"
-            )
+            ) from e
 
         document: DocumentSnapshot = (
-            await cls._get_col_ref().document(doc_id).get()
+            await cls._get_col_ref().document(doc_id).get(transaction=transaction)
         )  # type: ignore
         data = document.to_dict()
         if data is None:
@@ -253,7 +284,8 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     async def truncate_collection(cls, batch_size: int = 128) -> int:
-        """Removes all documents inside a collection.
+        """
+        Removes all documents inside a collection.
 
         :param batch_size: Batch size for listing documents.
         :return: Number of removed documents.
@@ -265,11 +297,16 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     def _get_col_ref(cls) -> AsyncCollectionReference:
-        """Returns the collection reference."""
+        """
+        Returns the collection reference.
+        """
         return _get_col_ref(cls, cls.__collection__)
 
     @classmethod
     def get_collection_name(cls) -> str:
+        """
+        Returns the collection name.
+        """
         return get_collection_name(cls, cls.__collection__)
 
     def _get_doc_ref(self) -> AsyncDocumentReference:
@@ -319,8 +356,19 @@ class AsyncModel(AsyncBareModel):
     id: Optional[str] = None
 
     @classmethod
-    async def get_by_id(cls: Type[TAsyncBareModel], id_: str) -> TAsyncBareModel:
-        return await cls.get_by_doc_id(id_)
+    async def get_by_id(
+        cls: Type[TAsyncBareModel],
+        id_: str,
+        transaction: Optional[AsyncTransaction] = None,
+    ) -> TAsyncBareModel:
+        """
+        Get single model by document ID.
+
+        :param id_: Document ID.
+        :param transaction: Optional Transaction to use.
+        :raises ModelNotFoundError:
+        """
+        return await cls.get_by_doc_id(id_, transaction=transaction)
 
 
 class AsyncBareSubCollection(ABC):
@@ -329,6 +377,9 @@ class AsyncBareSubCollection(ABC):
 
     @classmethod
     def model_for(cls, parent, model_class):
+        """
+        Returns the model for this subcollection.
+        """
         parent_props = parent.model_dump(by_alias=True)
 
         name = model_class.__name__
@@ -356,7 +407,9 @@ class AsyncBareSubModel(AsyncBareModel, ABC):
 
     @classmethod
     def _get_col_ref(cls) -> AsyncCollectionReference:
-        """Returns the collection reference."""
+        """
+        Returns the collection reference.
+        """
         if cls.__collection__ is None or "{" in cls.__collection__:
             raise CollectionNotDefined(
                 f"{cls.__name__} is not properly prepared. "
@@ -366,6 +419,9 @@ class AsyncBareSubModel(AsyncBareModel, ABC):
 
     @classmethod
     def model_for(cls, parent):
+        """
+        Returns the model for this submodel.
+        """
         return cls.Collection.model_for(parent, cls)
 
 
@@ -373,12 +429,19 @@ class AsyncSubModel(AsyncBareSubModel):
     id: Optional[str] = None
 
     @classmethod
-    async def get_by_id(cls: Type[TAsyncBareModel], id_: str) -> TAsyncBareModel:
+    async def get_by_id(
+        cls: Type[TAsyncBareModel],
+        id_: str,
+        transaction: Optional[AsyncTransaction] = None,
+    ) -> TAsyncBareModel:
         """
         Get single item by document ID
+
+        :param id_: Document ID.
+        :param transaction: Optional Transaction to use.
         :raises ModelNotFoundError:
         """
-        return await cls.get_by_doc_id(id_)
+        return await cls.get_by_doc_id(id_, transaction=transaction)
 
 
 class AsyncSubCollection(AsyncBareSubCollection, ABC):

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -368,7 +368,7 @@ class AsyncModel(AsyncBareModel):
 
         :param id_: Document ID.
         :param transaction: Optional transaction to use.
-        :raises ModelNotFoundError: if no model was found by given id
+        :raises ModelNotFoundError: If no model was found by given id.
         """
         return await cls.get_by_doc_id(id_, transaction=transaction)
 

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -84,7 +84,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
         :param exclude_unset: Whether to exclude fields that have not been explicitly set.
         :param exclude_none: Whether to exclude fields that have a value of `None`.
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :raise DocumentIDError: If the document ID is not valid.
         """
         data = self.model_dump(
@@ -115,7 +115,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
         """
         Reloads this model from the database.
 
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :raise ModelNotFoundError: If the document ID is missing in the model.
         """
         doc_id = self.__dict__.get(self.__document_id__)
@@ -164,7 +164,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
         :param order_by: List of columns and direction to order results by.
         :param limit: Maximum results to return.
         :param offset: Skip the first n results.
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :return: List of found models.
         """
         query: Union[AsyncQuery, AsyncCollectionReference] = cls._get_col_ref()
@@ -253,7 +253,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
         Returns a model based on the document ID.
 
         :param doc_id: The document ID of the entry.
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :return: The model.
         :raise ModelNotFoundError: Raised if no matching document is found.
         """
@@ -366,7 +366,7 @@ class AsyncModel(AsyncBareModel):
         Get single model by document ID.
 
         :param id_: Document ID.
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :raises ModelNotFoundError: if no model was found by given id
         """
         return await cls.get_by_doc_id(id_, transaction=transaction)
@@ -439,7 +439,7 @@ class AsyncSubModel(AsyncBareSubModel):
         Get single item by document ID
 
         :param id_: Document ID.
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :raises ModelNotFoundError:
         """
         return await cls.get_by_doc_id(id_, transaction=transaction)

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -15,10 +15,9 @@ from google.cloud.firestore_v1.async_transaction import AsyncTransaction
 import firedantic.operators as op
 from firedantic import async_truncate_collection
 from firedantic.common import IndexDefinition, OrderDirection
-from firedantic.configurations import CONFIGURATIONS, Configuration
+from firedantic.configurations import CONFIGURATIONS
 from firedantic.exceptions import (
     CollectionNotDefined,
-    ConfigurationNotFoundError,
     InvalidDocumentID,
     ModelNotFoundError,
 )
@@ -42,35 +41,20 @@ FIND_TYPES = {
 }
 
 
-def get_configuration(name: str = "default") -> Configuration:
-    """
-    Returns the configuration with the given name.
-
-    :params name: The configuration name.
-    :return: The configuration with the given name.
-    :raise ConfigurationNotFoundError: If the configuration is not found.
-    """
-    if name in CONFIGURATIONS:
-        return CONFIGURATIONS[name]
-    raise ConfigurationNotFoundError(f"Configuration `{name}` not found")
-
-
 def get_collection_name(cls, name: Optional[str]) -> str:
     """
-    Returns the collection name with the optional prefix.
+    Returns the collection name.
 
-    :params cls: The model class.
-    :params name: The collection name.
-    :return: The collection name with the optional prefix.
     :raise CollectionNotDefined: If the collection name is not defined.
     """
     if not name:
         raise CollectionNotDefined(f"Missing collection name for {cls.__name__}")
-    return f"{get_configuration().prefix}{name}"
+
+    return f"{CONFIGURATIONS['prefix']}{name}"
 
 
 def _get_col_ref(cls, name: Optional[str]) -> AsyncCollectionReference:
-    collection: AsyncCollectionReference = get_configuration().db.collection(
+    collection: AsyncCollectionReference = CONFIGURATIONS["db"].collection(
         get_collection_name(cls, name)
     )
     return collection

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -216,9 +216,10 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
                 _filter = FieldFilter(field, f_type, value[f_type])
                 query: AsyncQuery = query.where(filter=_filter)  # type: ignore
             return query
-        _filter = FieldFilter(field, "==", value)
-        query: AsyncQuery = query.where(filter=_filter)  # type: ignore
-        return query
+        else:
+            _filter = FieldFilter(field, "==", value)
+            query: AsyncQuery = query.where(filter=_filter)  # type: ignore
+            return query
 
     @classmethod
     async def find_one(

--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -15,9 +15,10 @@ from google.cloud.firestore_v1.async_transaction import AsyncTransaction
 import firedantic.operators as op
 from firedantic import async_truncate_collection
 from firedantic.common import IndexDefinition, OrderDirection
-from firedantic.configurations import CONFIGURATIONS
+from firedantic.configurations import CONFIGURATIONS, Configuration
 from firedantic.exceptions import (
     CollectionNotDefined,
+    ConfigurationNotFoundError,
     InvalidDocumentID,
     ModelNotFoundError,
 )
@@ -41,20 +42,35 @@ FIND_TYPES = {
 }
 
 
+def get_configuration(name: str = "default") -> Configuration:
+    """
+    Returns the configuration with the given name.
+
+    :params name: The configuration name.
+    :return: The configuration with the given name.
+    :raise ConfigurationNotFoundError: If the configuration is not found.
+    """
+    if name in CONFIGURATIONS:
+        return CONFIGURATIONS[name]
+    raise ConfigurationNotFoundError(f"Configuration `{name}` not found")
+
+
 def get_collection_name(cls, name: Optional[str]) -> str:
     """
-    Returns the collection name.
+    Returns the collection name with the optional prefix.
 
+    :params cls: The model class.
+    :params name: The collection name.
+    :return: The collection name with the optional prefix.
     :raise CollectionNotDefined: If the collection name is not defined.
     """
     if not name:
         raise CollectionNotDefined(f"Missing collection name for {cls.__name__}")
-
-    return f"{CONFIGURATIONS['prefix']}{name}"
+    return f"{get_configuration().prefix}{name}"
 
 
 def _get_col_ref(cls, name: Optional[str]) -> AsyncCollectionReference:
-    collection: AsyncCollectionReference = CONFIGURATIONS["db"].collection(
+    collection: AsyncCollectionReference = get_configuration().db.collection(
         get_collection_name(cls, name)
     )
     return collection
@@ -253,6 +269,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
         Returns a model based on the document ID.
 
         :param doc_id: The document ID of the entry.
+        :param transaction: Optional Transaction to use.
         :return: The model.
         :raise ModelNotFoundError: Raised if no matching document is found.
         """
@@ -366,7 +383,7 @@ class AsyncModel(AsyncBareModel):
 
         :param id_: Document ID.
         :param transaction: Optional Transaction to use.
-        :raises ModelNotFoundError:
+        :raises ModelNotFoundError: if no model was found by given id
         """
         return await cls.get_by_doc_id(id_, transaction=transaction)
 

--- a/firedantic/_sync/helpers.py
+++ b/firedantic/_sync/helpers.py
@@ -2,7 +2,8 @@ from google.cloud.firestore_v1 import CollectionReference
 
 
 def truncate_collection(col_ref: CollectionReference, batch_size: int = 128) -> int:
-    """Removes all documents inside a collection.
+    """
+    Removes all documents inside a collection.
 
     :param col_ref: A collection reference to the collection to be truncated.
     :param batch_size: Batch size for listing documents.

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -10,6 +10,7 @@ from google.cloud.firestore_v1 import (
     FieldFilter,
 )
 from google.cloud.firestore_v1.base_query import BaseQuery
+from google.cloud.firestore_v1.transaction import Transaction
 
 import firedantic.operators as op
 from firedantic import truncate_collection
@@ -41,6 +42,11 @@ FIND_TYPES = {
 
 
 def get_collection_name(cls, name: Optional[str]) -> str:
+    """
+    Returns the collection name.
+
+    :raise CollectionNotDefined: If the collection name is not defined.
+    """
     if not name:
         raise CollectionNotDefined(f"Missing collection name for {cls.__name__}")
 
@@ -55,7 +61,8 @@ def _get_col_ref(cls, name: Optional[str]) -> CollectionReference:
 
 
 class BareModel(pydantic.BaseModel, ABC):
-    """Base model class.
+    """
+    Base model class.
 
     Implements basic functionality for Pydantic models, such as save, delete, find etc.
     """
@@ -65,12 +72,19 @@ class BareModel(pydantic.BaseModel, ABC):
     __ttl_field__: Optional[str] = None
     __composite_indexes__: Optional[Iterable[IndexDefinition]] = None
 
-    def save(self, *, exclude_unset: bool = False, exclude_none: bool = False) -> None:
+    def save(
+        self,
+        *,
+        exclude_unset: bool = False,
+        exclude_none: bool = False,
+        transaction: Optional[Transaction] = None,
+    ) -> None:
         """
         Saves this model in the database.
 
         :param exclude_unset: Whether to exclude fields that have not been explicitly set.
         :param exclude_none: Whether to exclude fields that have a value of `None`.
+        :param transaction: Optional Transaction to use.
         :raise DocumentIDError: If the document ID is not valid.
         """
         data = self.model_dump(
@@ -80,28 +94,35 @@ class BareModel(pydantic.BaseModel, ABC):
             del data[self.__document_id__]
 
         doc_ref = self._get_doc_ref()
-        doc_ref.set(data)
+        if transaction is not None:
+            transaction.set(doc_ref, data)
+        else:
+            doc_ref.set(data)
         setattr(self, self.__document_id__, doc_ref.id)
 
-    def delete(self) -> None:
+    def delete(self, transaction: Optional[Transaction] = None) -> None:
         """
         Deletes this model from the database.
 
         :raise DocumentIDError: If the ID is not valid.
         """
-        self._get_doc_ref().delete()
+        if transaction is not None:
+            transaction.delete(self._get_doc_ref())
+        else:
+            self._get_doc_ref().delete()
 
-    def reload(self) -> None:
+    def reload(self, transaction: Optional[Transaction] = None) -> None:
         """
         Reloads this model from the database.
 
+        :param transaction: Optional Transaction to use.
         :raise ModelNotFoundError: If the document ID is missing in the model.
         """
         doc_id = self.__dict__.get(self.__document_id__)
         if doc_id is None:
             raise ModelNotFoundError("Can not reload unsaved model")
 
-        updated_model = self.get_by_doc_id(doc_id)
+        updated_model = self.get_by_doc_id(doc_id, transaction=transaction)
         updated_model_doc_id = updated_model.__dict__[self.__document_id__]
         assert doc_id == updated_model_doc_id
 
@@ -109,7 +130,7 @@ class BareModel(pydantic.BaseModel, ABC):
 
     def get_document_id(self):
         """
-        Get the document ID for this model instance
+        Returns the document ID for this model instance.
 
         :raise DocumentIDError: If the ID is not valid.
         """
@@ -121,14 +142,17 @@ class BareModel(pydantic.BaseModel, ABC):
     _OrderBy = List[Tuple[str, OrderDirection]]
 
     @classmethod
-    def find(
+    def find(  # pylint: disable=too-many-arguments
         cls: Type[TBareModel],
         filter_: Optional[Dict[str, Union[str, dict]]] = None,
         order_by: Optional[_OrderBy] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        transaction: Optional[Transaction] = None,
     ) -> List[TBareModel]:
-        """Returns a list of models from the database based on a filter.
+        """
+        Returns a list of models from the database based on a filter.
+
         The list can be sorted with the order_by parameter, limits and offets can also be applied.
 
         Example: `Company.find({"company_id": "1234567-8"})`.
@@ -140,6 +164,7 @@ class BareModel(pydantic.BaseModel, ABC):
         :param order_by: List of columns and direction to order results by.
         :param limit: Maximum results to return.
         :param offset: Skip the first n results.
+        :param transaction: Optional Transaction to use.
         :return: List of found models.
         """
         query: Union[BaseQuery, CollectionReference] = cls._get_col_ref()
@@ -173,7 +198,7 @@ class BareModel(pydantic.BaseModel, ABC):
         return [
             _cls(doc_id, doc_dict)
             for doc_id, doc_dict in (
-                (doc.id, doc.to_dict()) for doc in query.stream()  # type: ignore
+                (doc.id, doc.to_dict()) for doc in query.stream(transaction=transaction)  # type: ignore
             )
             if doc_dict is not None
         ]
@@ -182,7 +207,7 @@ class BareModel(pydantic.BaseModel, ABC):
     def _add_filter(
         cls, query: Union[BaseQuery, CollectionReference], field: str, value: Any
     ) -> Union[BaseQuery, CollectionReference]:
-        if type(value) is dict:
+        if isinstance(value, dict):
             for f_type in value:
                 if f_type not in FIND_TYPES:
                     raise ValueError(
@@ -191,33 +216,39 @@ class BareModel(pydantic.BaseModel, ABC):
                 _filter = FieldFilter(field, f_type, value[f_type])
                 query: BaseQuery = query.where(filter=_filter)  # type: ignore
             return query
-        else:
-            _filter = FieldFilter(field, "==", value)
-            query: BaseQuery = query.where(filter=_filter)  # type: ignore
-            return query
+        _filter = FieldFilter(field, "==", value)
+        query: BaseQuery = query.where(filter=_filter)  # type: ignore
+        return query
 
     @classmethod
     def find_one(
         cls: Type[TBareModel],
         filter_: Optional[Dict[str, Union[str, dict]]] = None,
         order_by: Optional[_OrderBy] = None,
+        transaction: Optional[Transaction] = None,
     ) -> TBareModel:
-        """Returns one model from the DB based on a filter.
+        """
+        Returns one model from the DB based on a filter.
 
         :param filter_: The filter criteria.
         :param order_by: List of columns and direction to order results by.
         :return: The model instance.
         :raise ModelNotFoundError: If the entry is not found.
         """
-        model = cls.find(filter_, limit=1, order_by=order_by)
+        model = cls.find(filter_, limit=1, order_by=order_by, transaction=transaction)
         try:
             return model[0]
-        except IndexError:
-            raise ModelNotFoundError(f"No '{cls.__name__}' found")
+        except IndexError as e:
+            raise ModelNotFoundError(f"No '{cls.__name__}' found") from e
 
     @classmethod
-    def get_by_doc_id(cls: Type[TBareModel], doc_id: str) -> TBareModel:
-        """Returns a model based on the document ID.
+    def get_by_doc_id(
+        cls: Type[TBareModel],
+        doc_id: str,
+        transaction: Optional[Transaction] = None,
+    ) -> TBareModel:
+        """
+        Returns a model based on the document ID.
 
         :param doc_id: The document ID of the entry.
         :return: The model.
@@ -226,7 +257,7 @@ class BareModel(pydantic.BaseModel, ABC):
 
         try:
             cls._validate_document_id(doc_id)
-        except InvalidDocumentID:
+        except InvalidDocumentID as e:
             # Getting a document with doc_id set to an empty string would raise a
             # google.api_core.exceptions.InvalidArgument exception and a doc_id
             # containing an uneven number of slashes would raise a
@@ -234,10 +265,10 @@ class BareModel(pydantic.BaseModel, ABC):
             # could even load data from a sub collection instead of the desired one.
             raise ModelNotFoundError(
                 f"No '{cls.__name__}' found with {cls.__document_id__} '{doc_id}'"
-            )
+            ) from e
 
         document: DocumentSnapshot = (
-            cls._get_col_ref().document(doc_id).get()
+            cls._get_col_ref().document(doc_id).get(transaction=transaction)
         )  # type: ignore
         data = document.to_dict()
         if data is None:
@@ -251,7 +282,8 @@ class BareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     def truncate_collection(cls, batch_size: int = 128) -> int:
-        """Removes all documents inside a collection.
+        """
+        Removes all documents inside a collection.
 
         :param batch_size: Batch size for listing documents.
         :return: Number of removed documents.
@@ -263,11 +295,16 @@ class BareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     def _get_col_ref(cls) -> CollectionReference:
-        """Returns the collection reference."""
+        """
+        Returns the collection reference.
+        """
         return _get_col_ref(cls, cls.__collection__)
 
     @classmethod
     def get_collection_name(cls) -> str:
+        """
+        Returns the collection name.
+        """
         return get_collection_name(cls, cls.__collection__)
 
     def _get_doc_ref(self) -> DocumentReference:
@@ -317,8 +354,19 @@ class Model(BareModel):
     id: Optional[str] = None
 
     @classmethod
-    def get_by_id(cls: Type[TBareModel], id_: str) -> TBareModel:
-        return cls.get_by_doc_id(id_)
+    def get_by_id(
+        cls: Type[TBareModel],
+        id_: str,
+        transaction: Optional[Transaction] = None,
+    ) -> TBareModel:
+        """
+        Get single model by document ID.
+
+        :param id_: Document ID.
+        :param transaction: Optional Transaction to use.
+        :raises ModelNotFoundError:
+        """
+        return cls.get_by_doc_id(id_, transaction=transaction)
 
 
 class BareSubCollection(ABC):
@@ -327,6 +375,9 @@ class BareSubCollection(ABC):
 
     @classmethod
     def model_for(cls, parent, model_class):
+        """
+        Returns the model for this subcollection.
+        """
         parent_props = parent.model_dump(by_alias=True)
 
         name = model_class.__name__
@@ -354,7 +405,9 @@ class BareSubModel(BareModel, ABC):
 
     @classmethod
     def _get_col_ref(cls) -> CollectionReference:
-        """Returns the collection reference."""
+        """
+        Returns the collection reference.
+        """
         if cls.__collection__ is None or "{" in cls.__collection__:
             raise CollectionNotDefined(
                 f"{cls.__name__} is not properly prepared. "
@@ -364,6 +417,9 @@ class BareSubModel(BareModel, ABC):
 
     @classmethod
     def model_for(cls, parent):
+        """
+        Returns the model for this submodel.
+        """
         return cls.Collection.model_for(parent, cls)
 
 
@@ -371,12 +427,19 @@ class SubModel(BareSubModel):
     id: Optional[str] = None
 
     @classmethod
-    def get_by_id(cls: Type[TBareModel], id_: str) -> TBareModel:
+    def get_by_id(
+        cls: Type[TBareModel],
+        id_: str,
+        transaction: Optional[Transaction] = None,
+    ) -> TBareModel:
         """
         Get single item by document ID
+
+        :param id_: Document ID.
+        :param transaction: Optional Transaction to use.
         :raises ModelNotFoundError:
         """
-        return cls.get_by_doc_id(id_)
+        return cls.get_by_doc_id(id_, transaction=transaction)
 
 
 class SubCollection(BareSubCollection, ABC):

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -84,7 +84,7 @@ class BareModel(pydantic.BaseModel, ABC):
 
         :param exclude_unset: Whether to exclude fields that have not been explicitly set.
         :param exclude_none: Whether to exclude fields that have a value of `None`.
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :raise DocumentIDError: If the document ID is not valid.
         """
         data = self.model_dump(
@@ -115,7 +115,7 @@ class BareModel(pydantic.BaseModel, ABC):
         """
         Reloads this model from the database.
 
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :raise ModelNotFoundError: If the document ID is missing in the model.
         """
         doc_id = self.__dict__.get(self.__document_id__)
@@ -164,7 +164,7 @@ class BareModel(pydantic.BaseModel, ABC):
         :param order_by: List of columns and direction to order results by.
         :param limit: Maximum results to return.
         :param offset: Skip the first n results.
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :return: List of found models.
         """
         query: Union[BaseQuery, CollectionReference] = cls._get_col_ref()
@@ -251,7 +251,7 @@ class BareModel(pydantic.BaseModel, ABC):
         Returns a model based on the document ID.
 
         :param doc_id: The document ID of the entry.
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :return: The model.
         :raise ModelNotFoundError: Raised if no matching document is found.
         """
@@ -364,7 +364,7 @@ class Model(BareModel):
         Get single model by document ID.
 
         :param id_: Document ID.
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :raises ModelNotFoundError: if no model was found by given id
         """
         return cls.get_by_doc_id(id_, transaction=transaction)
@@ -437,7 +437,7 @@ class SubModel(BareSubModel):
         Get single item by document ID
 
         :param id_: Document ID.
-        :param transaction: Optional Transaction to use.
+        :param transaction: Optional transaction to use.
         :raises ModelNotFoundError:
         """
         return cls.get_by_doc_id(id_, transaction=transaction)

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -216,9 +216,10 @@ class BareModel(pydantic.BaseModel, ABC):
                 _filter = FieldFilter(field, f_type, value[f_type])
                 query: BaseQuery = query.where(filter=_filter)  # type: ignore
             return query
-        _filter = FieldFilter(field, "==", value)
-        query: BaseQuery = query.where(filter=_filter)  # type: ignore
-        return query
+        else:
+            _filter = FieldFilter(field, "==", value)
+            query: BaseQuery = query.where(filter=_filter)  # type: ignore
+            return query
 
     @classmethod
     def find_one(

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -15,10 +15,9 @@ from google.cloud.firestore_v1.transaction import Transaction
 import firedantic.operators as op
 from firedantic import truncate_collection
 from firedantic.common import IndexDefinition, OrderDirection
-from firedantic.configurations import CONFIGURATIONS, Configuration
+from firedantic.configurations import CONFIGURATIONS
 from firedantic.exceptions import (
     CollectionNotDefined,
-    ConfigurationNotFoundError,
     InvalidDocumentID,
     ModelNotFoundError,
 )
@@ -42,35 +41,20 @@ FIND_TYPES = {
 }
 
 
-def get_configuration(name: str = "default") -> Configuration:
-    """
-    Returns the configuration with the given name.
-
-    :params name: The configuration name.
-    :return: The configuration with the given name.
-    :raise ConfigurationNotFoundError: If the configuration is not found.
-    """
-    if name in CONFIGURATIONS:
-        return CONFIGURATIONS[name]
-    raise ConfigurationNotFoundError(f"Configuration `{name}` not found")
-
-
 def get_collection_name(cls, name: Optional[str]) -> str:
     """
-    Returns the collection name with the optional prefix.
+    Returns the collection name.
 
-    :params cls: The model class.
-    :params name: The collection name.
-    :return: The collection name with the optional prefix.
     :raise CollectionNotDefined: If the collection name is not defined.
     """
     if not name:
         raise CollectionNotDefined(f"Missing collection name for {cls.__name__}")
-    return f"{get_configuration().prefix}{name}"
+
+    return f"{CONFIGURATIONS['prefix']}{name}"
 
 
 def _get_col_ref(cls, name: Optional[str]) -> CollectionReference:
-    collection: CollectionReference = get_configuration().db.collection(
+    collection: CollectionReference = CONFIGURATIONS["db"].collection(
         get_collection_name(cls, name)
     )
     return collection

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -366,7 +366,7 @@ class Model(BareModel):
 
         :param id_: Document ID.
         :param transaction: Optional transaction to use.
-        :raises ModelNotFoundError: if no model was found by given id
+        :raises ModelNotFoundError: If no model was found by given id.
         """
         return cls.get_by_doc_id(id_, transaction=transaction)
 

--- a/firedantic/configurations.py
+++ b/firedantic/configurations.py
@@ -1,58 +1,17 @@
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
 from google.cloud.firestore_v1 import AsyncClient, Client
-from pydantic import BaseModel
 
-
-class Configuration(BaseModel):
-    """
-    Defines a single configuration.
-    """
-
-    db: Union[Client, AsyncClient]
-    prefix: str = ""
-
-
-class ConfigurationDict(dict):
-    """
-    A dictionary-like object to handle multiple configurations with backward compatibility.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def __setitem__(self, key, value):
-        if key in ("db", "prefix"):
-            raise ValueError(f"Cannot create configuration named '{key}'.")
-        super().__setitem__(key, value)
-
-    def __getitem__(self, key):
-        if "default" not in self or not self["default"] is None:
-            raise ValueError(
-                "No default configuration found. Run `configure` to get started."
-            )
-        if key == "db":
-            return self["default"]
-        if key == "prefix":
-            return self["default"].prefix
-        return super().__getitem__(key)
-
-
-CONFIGURATIONS: Dict[str, Configuration] = ConfigurationDict()
+CONFIGURATIONS: Dict[str, Any] = {}
 
 
 def configure(db: Union[Client, AsyncClient], prefix: str = "") -> None:
-    """
-    Configures the prefix and DB.
+    """Configures the prefix and DB.
 
     :param db: The firestore client instance.
     :param prefix: The prefix to use for collection names.
     """
-    global CONFIGURATIONS  # pylint: disable=global-statement,global-variable-not-assigned
+    global CONFIGURATIONS
 
-    # CONFIGURATIONS["db"] = db
-    # CONFIGURATIONS["prefix"] = prefix
-
-    configuration = Configuration(db=db, prefix=prefix)
-
-    CONFIGURATIONS["default"] = configuration
+    CONFIGURATIONS["db"] = db
+    CONFIGURATIONS["prefix"] = prefix

--- a/firedantic/configurations.py
+++ b/firedantic/configurations.py
@@ -1,17 +1,58 @@
-from typing import Any, Dict, Union
+from typing import Dict, Union
 
 from google.cloud.firestore_v1 import AsyncClient, Client
+from pydantic import BaseModel
 
-CONFIGURATIONS: Dict[str, Any] = {}
+
+class Configuration(BaseModel):
+    """
+    Defines a single configuration.
+    """
+
+    db: Union[Client, AsyncClient]
+    prefix: str = ""
+
+
+class ConfigurationDict(dict):
+    """
+    A dictionary-like object to handle multiple configurations with backward compatibility.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def __setitem__(self, key, value):
+        if key in ("db", "prefix"):
+            raise ValueError(f"Cannot create configuration named '{key}'.")
+        super().__setitem__(key, value)
+
+    def __getitem__(self, key):
+        if "default" not in self or not self["default"] is None:
+            raise ValueError(
+                "No default configuration found. Run `configure` to get started."
+            )
+        if key == "db":
+            return self["default"]
+        if key == "prefix":
+            return self["default"].prefix
+        return super().__getitem__(key)
+
+
+CONFIGURATIONS: Dict[str, Configuration] = ConfigurationDict()
 
 
 def configure(db: Union[Client, AsyncClient], prefix: str = "") -> None:
-    """Configures the prefix and DB.
+    """
+    Configures the prefix and DB.
 
     :param db: The firestore client instance.
     :param prefix: The prefix to use for collection names.
     """
-    global CONFIGURATIONS
+    global CONFIGURATIONS  # pylint: disable=global-statement,global-variable-not-assigned
 
-    CONFIGURATIONS["db"] = db
-    CONFIGURATIONS["prefix"] = prefix
+    # CONFIGURATIONS["db"] = db
+    # CONFIGURATIONS["prefix"] = prefix
+
+    configuration = Configuration(db=db, prefix=prefix)
+
+    CONFIGURATIONS["default"] = configuration

--- a/firedantic/configurations.py
+++ b/firedantic/configurations.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Union
 
-from google.cloud.firestore_v1 import AsyncClient, Client
+from google.cloud.firestore_v1 import AsyncClient, AsyncTransaction, Client, Transaction
 
 CONFIGURATIONS: Dict[str, Any] = {}
 
@@ -15,3 +15,21 @@ def configure(db: Union[Client, AsyncClient], prefix: str = "") -> None:
 
     CONFIGURATIONS["db"] = db
     CONFIGURATIONS["prefix"] = prefix
+
+
+def get_transaction() -> Transaction:
+    """
+    Get a new Firestore transaction for the configured DB.
+    """
+    transaction = CONFIGURATIONS["db"].transaction()
+    assert isinstance(transaction, Transaction)
+    return transaction
+
+
+def get_async_transaction() -> AsyncTransaction:
+    """
+    Get a new Firestore transaction for the configured DB.
+    """
+    transaction = CONFIGURATIONS["db"].transaction()
+    assert isinstance(transaction, AsyncTransaction)
+    return transaction

--- a/firedantic/exceptions.py
+++ b/firedantic/exceptions.py
@@ -1,10 +1,3 @@
-"""Firedantic Exceptions module."""
-
-
-class ConfigurationNotFoundError(Exception):
-    """Raised when a configuration is not found."""
-
-
 class ModelError(Exception):
     """Generic model error class."""
 

--- a/firedantic/exceptions.py
+++ b/firedantic/exceptions.py
@@ -1,16 +1,21 @@
+"""Firedantic Exceptions module."""
+
+
+class ConfigurationNotFoundError(Exception):
+    """Raised when a configuration is not found."""
+
+
 class ModelError(Exception):
     """Generic model error class."""
 
-    pass
-
 
 class InvalidDocumentID(ModelError):
-    pass
+    """Raised when a document ID is invalid."""
 
 
 class ModelNotFoundError(ModelError):
-    pass
+    """Raised when a model is not found."""
 
 
 class CollectionNotDefined(ModelError):
-    pass
+    """Raised when the model collection is not defined."""

--- a/firedantic/tests/tests_async/conftest.py
+++ b/firedantic/tests/tests_async/conftest.py
@@ -6,7 +6,7 @@ import google.auth.credentials
 import pytest
 from google.cloud.firestore_admin_v1 import Field, FirestoreAdminClient
 from google.cloud.firestore_v1 import AsyncClient
-from pydantic import BaseModel, Extra, PrivateAttr
+from pydantic import BaseModel, PrivateAttr
 
 from firedantic import (
     AsyncBareModel,
@@ -30,7 +30,7 @@ class CustomIDModel(AsyncBareModel):
     bar: str
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class CustomIDModelExtra(AsyncBareModel):
@@ -42,7 +42,7 @@ class CustomIDModelExtra(AsyncBareModel):
     baz: str
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class CustomIDConflictModel(AsyncModel):
@@ -52,7 +52,7 @@ class CustomIDConflictModel(AsyncModel):
     bar: str
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class Owner(BaseModel):
@@ -62,7 +62,7 @@ class Owner(BaseModel):
     last_name: str
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class CompanyStats(AsyncBareSubModel):
@@ -99,7 +99,7 @@ class Company(AsyncModel):
     owner: Owner
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     def stats(self) -> Type[CompanyStats]:
         return CompanyStats.model_for(self)  # type: ignore
@@ -115,7 +115,7 @@ class Product(AsyncModel):
     stock: int
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class Profile(AsyncModel):
@@ -124,10 +124,11 @@ class Profile(AsyncModel):
     __collection__ = "profiles"
 
     name: Optional[str] = ""
+    email: Optional[str] = None
     photo_url: Optional[str] = None
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class TodoList(AsyncModel):
@@ -139,7 +140,7 @@ class TodoList(AsyncModel):
     items: List[str]
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class ExpiringModel(AsyncModel):

--- a/firedantic/tests/tests_async/conftest.py
+++ b/firedantic/tests/tests_async/conftest.py
@@ -141,7 +141,6 @@ class Profile(AsyncModel):
     __collection__ = "profiles"
 
     name: Optional[str] = ""
-    email: Optional[str] = None
     photo_url: Optional[str] = None
 
     class Config:

--- a/firedantic/tests/tests_async/conftest.py
+++ b/firedantic/tests/tests_async/conftest.py
@@ -55,6 +55,13 @@ class CustomIDConflictModel(AsyncModel):
         extra = "forbid"
 
 
+class City(AsyncModel):
+    """Dummy city Firedantic model."""
+
+    __collection__ = "cities"
+    population: int
+
+
 class Owner(BaseModel):
     """Dummy owner Pydantic model."""
 

--- a/firedantic/tests/tests_async/test_model.py
+++ b/firedantic/tests/tests_async/test_model.py
@@ -514,7 +514,7 @@ async def test_save_with_exclude_none(configure_db) -> None:
     document = await Profile._get_col_ref().document(document_id).get()
 
     data = document.to_dict()
-    assert data == {"name": "Foo", "email": None, "photo_url": None}
+    assert data == {"name": "Foo", "photo_url": None}
 
 
 @pytest.mark.asyncio
@@ -536,7 +536,7 @@ async def test_save_with_exclude_unset(configure_db) -> None:
     document = await Profile._get_col_ref().document(document_id).get()
 
     data = document.to_dict()
-    assert data == {"name": "", "email": None, "photo_url": None}
+    assert data == {"name": "", "photo_url": None}
 
 
 @pytest.mark.asyncio

--- a/firedantic/tests/tests_async/test_model.py
+++ b/firedantic/tests/tests_async/test_model.py
@@ -573,7 +573,7 @@ async def test_delete_in_transaction(configure_db) -> None:
     :param: configure_db: pytest fixture
     """
 
-    @async_transactional  # type: ignore
+    @async_transactional
     async def delete_in_transaction(
         transaction: AsyncTransaction, profile_id: str
     ) -> None:
@@ -600,7 +600,7 @@ async def test_update_model_in_transaction(configure_db) -> None:
     :param: configure_db: pytest fixture
     """
 
-    @async_transactional  # type: ignore
+    @async_transactional
     async def update_in_transaction(
         transaction: AsyncTransaction, profile_id: str, name: str
     ) -> None:
@@ -627,7 +627,7 @@ async def test_update_submodel_in_transaction(configure_db) -> None:
     :param: configure_db: pytest fixture
     """
 
-    @async_transactional  # type: ignore
+    @async_transactional
     async def update_submodel_in_transaction(
         transaction: AsyncTransaction, user_id: str, period: str
     ) -> UserStats:

--- a/firedantic/tests/tests_sync/conftest.py
+++ b/firedantic/tests/tests_sync/conftest.py
@@ -6,7 +6,7 @@ import google.auth.credentials
 import pytest
 from google.cloud.firestore_admin_v1 import Field, FirestoreAdminClient
 from google.cloud.firestore_v1 import Client
-from pydantic import BaseModel, Extra, PrivateAttr
+from pydantic import BaseModel, PrivateAttr
 
 from firedantic import (
     BareModel,
@@ -30,7 +30,7 @@ class CustomIDModel(BareModel):
     bar: str
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class CustomIDModelExtra(BareModel):
@@ -42,7 +42,7 @@ class CustomIDModelExtra(BareModel):
     baz: str
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class CustomIDConflictModel(Model):
@@ -52,7 +52,7 @@ class CustomIDConflictModel(Model):
     bar: str
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class Owner(BaseModel):
@@ -62,7 +62,7 @@ class Owner(BaseModel):
     last_name: str
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class CompanyStats(BareSubModel):
@@ -99,7 +99,7 @@ class Company(Model):
     owner: Owner
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     def stats(self) -> Type[CompanyStats]:
         return CompanyStats.model_for(self)  # type: ignore
@@ -115,7 +115,7 @@ class Product(Model):
     stock: int
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class Profile(Model):
@@ -124,10 +124,11 @@ class Profile(Model):
     __collection__ = "profiles"
 
     name: Optional[str] = ""
+    email: Optional[str] = None
     photo_url: Optional[str] = None
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class TodoList(Model):
@@ -139,7 +140,7 @@ class TodoList(Model):
     items: List[str]
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
 
 class ExpiringModel(Model):

--- a/firedantic/tests/tests_sync/conftest.py
+++ b/firedantic/tests/tests_sync/conftest.py
@@ -55,6 +55,13 @@ class CustomIDConflictModel(Model):
         extra = "forbid"
 
 
+class City(Model):
+    """Dummy city Firedantic model."""
+
+    __collection__ = "cities"
+    population: int
+
+
 class Owner(BaseModel):
     """Dummy owner Pydantic model."""
 

--- a/firedantic/tests/tests_sync/conftest.py
+++ b/firedantic/tests/tests_sync/conftest.py
@@ -141,7 +141,6 @@ class Profile(Model):
     __collection__ = "profiles"
 
     name: Optional[str] = ""
-    email: Optional[str] = None
     photo_url: Optional[str] = None
 
     class Config:

--- a/firedantic/tests/tests_sync/test_model.py
+++ b/firedantic/tests/tests_sync/test_model.py
@@ -480,7 +480,7 @@ def test_save_with_exclude_none(configure_db) -> None:
     document = Profile._get_col_ref().document(document_id).get()
 
     data = document.to_dict()
-    assert data == {"name": "Foo", "email": None, "photo_url": None}
+    assert data == {"name": "Foo", "photo_url": None}
 
 
 def test_save_with_exclude_unset(configure_db) -> None:
@@ -501,7 +501,7 @@ def test_save_with_exclude_unset(configure_db) -> None:
     document = Profile._get_col_ref().document(document_id).get()
 
     data = document.to_dict()
-    assert data == {"name": "", "email": None, "photo_url": None}
+    assert data == {"name": "", "photo_url": None}
 
 
 def test_update_city_in_transaction(configure_db) -> None:

--- a/firedantic/tests/tests_sync/test_model.py
+++ b/firedantic/tests/tests_sync/test_model.py
@@ -534,7 +534,7 @@ def test_delete_in_transaction(configure_db) -> None:
     :param: configure_db: pytest fixture
     """
 
-    @transactional  # type: ignore
+    @transactional
     def delete_in_transaction(transaction: Transaction, profile_id: str) -> None:
         """Deletes a Profile in a transaction."""
         profile = Profile.get_by_id(profile_id, transaction=transaction)
@@ -558,7 +558,7 @@ def test_update_model_in_transaction(configure_db) -> None:
     :param: configure_db: pytest fixture
     """
 
-    @transactional  # type: ignore
+    @transactional
     def update_in_transaction(
         transaction: Transaction, profile_id: str, name: str
     ) -> None:
@@ -584,7 +584,7 @@ def test_update_submodel_in_transaction(configure_db) -> None:
     :param: configure_db: pytest fixture
     """
 
-    @transactional  # type: ignore
+    @transactional
     def update_submodel_in_transaction(
         transaction: Transaction, user_id: str, period: str
     ) -> UserStats:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "firedantic"
-version = "0.10.0"
+version = "0.11.0"
 description = "Pydantic base models for Firestore"
 authors = ["IOXIO Ltd"]
 license = "BSD-3-Clause"

--- a/unasync.py
+++ b/unasync.py
@@ -5,6 +5,12 @@ import re
 from pathlib import Path
 
 SUBS = [
+    (
+        "from google.cloud.firestore_v1.async_transaction",
+        "from google.cloud.firestore_v1.transaction",
+    ),
+    ("async_transactional", "transactional"),
+    ("AsyncTransaction", "Transaction"),
     ("google.cloud.firestore_v1.async_query", "google.cloud.firestore_v1.base_query"),
     ("AsyncQuery", "BaseQuery"),
     ("AsyncCollectionReference", "CollectionReference"),

--- a/unasync.py
+++ b/unasync.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 
 SUBS = [
+    ("get_async_transaction", "get_transaction"),
     (
         "from google.cloud.firestore_v1.async_transaction",
         "from google.cloud.firestore_v1.transaction",


### PR DESCRIPTION
This PR includes support for Firebase transactions.  Specifically, the following methods now take an optional `transaction` argument.

- `Model.delete(transaction=transaction)`
- `Model.find_one(transaction=transaction)`
- `Model.find(transaction=transaction)`
- `Model.get_by_doc_id(transaction=transaction)`
- `Model.get_by_id(transaction=transaction)`
- `Model.reload(transaction=transaction)`
- `Model.save(transaction=transaction)`
- `SubModel.get_by_id(transaction=transaction)`

I've included a new section in the README with an example of using async transactions and there is a unit test that covers the same case as the README. 

Let me know if you have any questions and thanks for your consideration!