### PR TITLE
Fix type signature for filter_ parameter in find methods

### DIFF
--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -144,7 +144,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
     @classmethod
     async def find(  # pylint: disable=too-many-arguments
         cls: Type[TAsyncBareModel],
-        filter_: Optional[Dict[str, Union[str, dict]]] = None,
+        filter_: Optional[Dict[str, Union[str, int, float, bool, dict]]] = None,
         order_by: Optional[_OrderBy] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
@@ -224,7 +224,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
     @classmethod
     async def find_one(
         cls: Type[TAsyncBareModel],
-        filter_: Optional[Dict[str, Union[str, dict]]] = None,
+        filter_: Optional[Dict[str, Union[str, int, float, bool, dict]]] = None,
         order_by: Optional[_OrderBy] = None,
         transaction: Optional[AsyncTransaction] = None,
     ) -> TAsyncBareModel:

--- a/firedantic/_sync/helpers.py
+++ b/firedantic/_sync/helpers.py
@@ -1,7 +1,9 @@
 from google.cloud.firestore_v1 import CollectionReference
 
 
-def truncate_collection(col_ref: CollectionReference, batch_size: int = 128) -> int:
+def truncate_collection(
+    col_ref: CollectionReference, batch_size: int = 128
+) -> int:
     """
     Removes all documents inside a collection.
 

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -144,7 +144,7 @@ class BareModel(pydantic.BaseModel, ABC):
     @classmethod
     def find(  # pylint: disable=too-many-arguments
         cls: Type[TBareModel],
-        filter_: Optional[Dict[str, Union[str, dict]]] = None,
+        filter_: Optional[Dict[str, Union[str, int, float, bool, dict]]] = None,
         order_by: Optional[_OrderBy] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
@@ -224,7 +224,7 @@ class BareModel(pydantic.BaseModel, ABC):
     @classmethod
     def find_one(
         cls: Type[TBareModel],
-        filter_: Optional[Dict[str, Union[str, dict]]] = None,
+        filter_: Optional[Dict[str, Union[str, int, float, bool, dict]]] = None,
         order_by: Optional[_OrderBy] = None,
         transaction: Optional[Transaction] = None,
     ) -> TBareModel:
@@ -236,7 +236,9 @@ class BareModel(pydantic.BaseModel, ABC):
         :return: The model instance.
         :raise ModelNotFoundError: If the entry is not found.
         """
-        model = cls.find(filter_, limit=1, order_by=order_by, transaction=transaction)
+        model = cls.find(
+            filter_, limit=1, order_by=order_by, transaction=transaction
+        )
         try:
             return model[0]
         except IndexError as e:


### PR DESCRIPTION
## Summary
- Fixed type signature for `filter_` parameter in `find()` and `find_one()` methods
- Now correctly supports `int`, `float`, and `bool` types in addition to `str`
- Updated both async and sync versions via unasync

## Test plan
- [x] Syntax validation passed
- [x] Module import test passed
- [x] Generated sync version correctly updated

The change aligns with actual Firestore usage patterns shown in the README examples where integer values are used in filters.